### PR TITLE
#6: Removes pycrypto from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ requests==2.29.0
 update-checker==0.18.0
 urllib3==1.26.15
 websocket-client==1.5.1
-pycrypto==2.6.1
 pycryptodome==3.21.0


### PR DESCRIPTION
pycrypto is deprecated and recommends using pycryptodome which is already being installed since it is in the requirements.txt. The pycrypto package install fails when running the pip install command on windows machines.